### PR TITLE
use install_requires for compatibility with pip>=20.1

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include LICENSE
-include requirements.txt
 include README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-oauthlib==2.0.1
-requests==2.20.0
-requests-oauthlib==0.7.0
-six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,6 @@ import uuid
 
 from setuptools import setup, find_packages
 
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
-install_requirements = parse_requirements('requirements.txt', session=uuid.uuid1())
-requirements = [str(req.req) for req in install_requirements]
-
 setup(
     name="python-unsplash",
     version="1.0.0",
@@ -22,7 +14,12 @@ setup(
     author_email="yakup.adakli@gmail.com",
     url="http://github.com/yakupadakli/python-unsplash.git",
     packages=find_packages(exclude=["tests"]),
-    install_requires=requirements,
+    install_requires=[
+        "oauthlib==2.0.1",
+        "requests==2.20.0",
+        "requests-oauthlib==0.7.0",
+        "six==1.10.0",
+    ],
     keywords="unsplash library",
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I noticed python-unsplash setup just started failing in one of my projects.

There was a backwards-incompatible change in pip 20.1. It looks like the recommendation is to just use install_requires. Tested manually under pip 18.1 and 20.1.